### PR TITLE
fixes a PHP strict standards notice

### DIFF
--- a/src/Knp/Rad/ViewRenderer/DependencyInjection/Compiler/RendererPass.php
+++ b/src/Knp/Rad/ViewRenderer/DependencyInjection/Compiler/RendererPass.php
@@ -21,7 +21,8 @@ class RendererPass implements CompilerPassInterface
         $listener  = $container->getDefinition('knp_rad_view_renderer.event_listener.view_listener');
 
         foreach ($renderers as $id => $tags) {
-            $rendererName = str_replace('_renderer', '', array_pop((explode('.', $id))));
+            $idParts = explode('.', $id);
+            $rendererName = str_replace('_renderer', '', array_pop($idParts));
 
             if (false !== strpos($id, 'knp_rad_view_renderer.renderer.') && !in_array($rendererName, $nativeEnabled)) {
                 $container->removeDefinition($id);


### PR DESCRIPTION
fixes the notice "[Symfony\Component\Debug\Exception\ContextErrorException]
  Notice: Only variables should be passed by reference" when clearing the symfony cache.
